### PR TITLE
Fix arrayIndexScale

### DIFF
--- a/openjdk/sun/misc/Unsafe.java
+++ b/openjdk/sun/misc/Unsafe.java
@@ -117,7 +117,7 @@ public final class Unsafe
         {
             return 2;
         }
-        if (c == int[].class || c == float[].class)
+        if (c == int[].class || c == float[].class || c == Object[].class)
         {
             return 4;
         }


### PR DESCRIPTION
When an object array is passed to arrayIndexScale it should return 4.