### PR TITLE
Fix for EmitBox InvalidOperationException Bug

### DIFF
--- a/runtime/LambdaMetafactory.cs
+++ b/runtime/LambdaMetafactory.cs
@@ -634,7 +634,12 @@ namespace IKVM.Internal
 				}
 				else if (Ra.IsPrimitive)
 				{
-					Boxer.EmitBox(ilgen, GetPrimitiveFromWrapper(Rt));
+					TypeWrapper tw = GetPrimitiveFromWrapper(Rt);
+					if (tw == null)
+					{
+						tw = Ra;
+					}
+					Boxer.EmitBox(ilgen, tw);
 				}
 				else
 				{


### PR DESCRIPTION
Checking the TypeWrapper value before passing into EmitBox.